### PR TITLE
perf: remove console statements in prod

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,14 +1,23 @@
-module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
-  plugins: [
-    [
-      'module-resolver',
-      {
-        alias: {
-          '@cash': './src',
-          '@playground': './playground',
-        },
+const presets = ['module:metro-react-native-babel-preset'];
+const plugins = [
+  [
+    'module-resolver',
+    {
+      alias: {
+        '@cash': './src',
+        '@playground': './playground',
       },
-    ],
+    },
   ],
+];
+
+module.exports = {
+  presets,
+  plugins,
+  env: {
+    production: {
+      presets,
+      plugins: [...plugins, ['transform-remove-console']],
+    },
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/runtime": "7.12.5",
         "@react-native-community/eslint-config": "3.0.1",
         "babel-plugin-module-resolver": "4.1.0",
+        "babel-plugin-transform-remove-console": "6.9.4",
         "eslint": "7.32.0",
         "husky": "7.0.2",
         "lint-staged": "11.1.2",
@@ -3812,6 +3813,12 @@
       "version": "7.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
       "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+    },
+    "node_modules/babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+      "dev": true
     },
     "node_modules/babel-preset-fbjs": {
       "version": "3.4.0",
@@ -14683,6 +14690,12 @@
       "version": "7.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
       "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+    },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+      "dev": true
     },
     "babel-preset-fbjs": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/runtime": "7.12.5",
     "@react-native-community/eslint-config": "3.0.1",
     "babel-plugin-module-resolver": "4.1.0",
+    "babel-plugin-transform-remove-console": "6.9.4",
     "eslint": "7.32.0",
     "husky": "7.0.2",
     "lint-staged": "11.1.2",


### PR DESCRIPTION
This PR makes sure that we remove `console` statements in production.
These statements can cause a big bottleneck in the JavaScript thread.

More info: https://reactnative.dev/docs/performance#using-consolelog-statements