### PR TITLE
Increase ButtonBase variant heights

### DIFF
--- a/src/Button/ButtonBase.js
+++ b/src/Button/ButtonBase.js
@@ -14,8 +14,8 @@ const defaultSizeProp = 'lg';
 const sizeVariants = variant({
   prop: 'size',
   variants: {
-    md: { height: 46 },
     lg: { height: 60 },
+    md: { height: 48 },
     sm: { height: 30 },
   },
 });


### PR DESCRIPTION
This PR slightly increases the height for the following variants:

- lg `56 => 60`
- md `46 => 48`

Includes `<Button />` + `<ButtonPrimary />`

Related: https://www.notion.so/Rating-and-Sign-out-button-Design-is-wrong-31c160b3e9094982a8fe072d4f189291