### PR TITLE
fix(ButtonPrimary): icon support

### DIFF
--- a/src/Button/ButtonPrimary.js
+++ b/src/Button/ButtonPrimary.js
@@ -31,6 +31,8 @@ const ButtonPrimary = ({
   isLoading,
   loadingText,
   hasShadow,
+  leftIcon,
+  rightIcon,
   size,
   colorScheme,
   ...props
@@ -66,6 +68,8 @@ const ButtonPrimary = ({
               size={size}
               isLoading={isLoading}
               loadingText={loadingText}
+              leftIcon={leftIcon}
+              rightIcon={rightIcon}
               {...textProps}
             >
               {children}


### PR DESCRIPTION
This PR fixes support for the `leftIcon` & `rightIcon` prop for the `<ButtonPrimary />`.