### PR TITLE
feat: introduce "PlatformVisible" component

### DIFF
--- a/src/PlatformVisible.js
+++ b/src/PlatformVisible.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types';
+import { Platform } from 'react-native';
+
+const PlatformVisible = ({ target, children }) => (Platform.OS === target ? children : null);
+
+PlatformVisible.propTypes = {
+  target: PropTypes.oneOf(['android', 'ios']).isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default PlatformVisible;

--- a/src/index.js
+++ b/src/index.js
@@ -14,5 +14,6 @@ export { default as Card } from './Card';
 export { default as Heading } from './Heading';
 export { default as Icon } from './Icon';
 export { default as Link } from './Link';
+export { default as PlatformVisible } from './PlatformVisible';
 export { default as Text } from './Text';
 export { default as GradientText } from './GradientText';


### PR DESCRIPTION
This PR introduces a "PlatformVisible" component. This way we can easily render content based on the platform.

```jsx
<PlatformVisible target="ios">
  <Text>Visible on iOS only</Text>
</PlatformVisible>
```

```jsx
<PlatformVisible target="android">
  <Text>Visible on Android only</Text>
</PlatformVisible>
```