### PR TITLE
feat(Button): introduce "translucent" color scheme

### DIFF
--- a/playground/stories/Button/Button.stories.js
+++ b/playground/stories/Button/Button.stories.js
@@ -2,26 +2,37 @@ import React from 'react';
 import * as Cash from '@cash';
 
 export default () => (
-  <Cash.Card bg="black.25">
-    <Cash.Button mb="3">Button text</Cash.Button>
-    <Cash.Button mb="3" hasShadow>
-      Button text
-    </Cash.Button>
-    <Cash.Button leftIcon={<Cash.Icon name="LeftArrow" />} mb="3">
-      Button text
-    </Cash.Button>
-    <Cash.Button rightIcon={<Cash.Icon name="RightArrow" />} mb="3">
-      Button text
-    </Cash.Button>
-    <Cash.Button mb="3" loadingText="Loading..." isLoading>
-      Button text
-    </Cash.Button>
-    <Cash.Button mb="3" isFullWidth isDisabled>
-      Disabled
-    </Cash.Button>
-    <Cash.Button size="md" mb="3">
-      Button text
-    </Cash.Button>
-    <Cash.Button size="sm">Button text</Cash.Button>
-  </Cash.Card>
+  <>
+    <Cash.Card bg="black.25">
+      <Cash.Button mb="3">Button text</Cash.Button>
+      <Cash.Button mb="3" hasShadow>
+        Button text
+      </Cash.Button>
+      <Cash.Button leftIcon={<Cash.Icon name="LeftArrow" />} mb="3">
+        Button text
+      </Cash.Button>
+      <Cash.Button rightIcon={<Cash.Icon name="RightArrow" />} mb="3">
+        Button text
+      </Cash.Button>
+      <Cash.Button mb="3" loadingText="Loading..." isLoading>
+        Button text
+      </Cash.Button>
+      <Cash.Button mb="3" isDisabled>
+        Disabled
+      </Cash.Button>
+      <Cash.Button size="md" mb="3">
+        Button text
+      </Cash.Button>
+      <Cash.Button size="sm">Button text</Cash.Button>
+    </Cash.Card>
+
+    <Cash.Card bg="purple.700" mt={3}>
+      <Cash.Stack direction="column" gap="16px">
+        <Cash.Button colorScheme="translucent">Translucent</Cash.Button>
+        <Cash.Button colorScheme="translucent" isDisabled>
+          Translucent disabled
+        </Cash.Button>
+      </Cash.Stack>
+    </Cash.Card>
+  </>
 );

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -7,6 +7,10 @@ const colorSchemes = {
     bg: 'white',
     color: 'black.400',
   },
+  translucent: {
+    bg: 'rgba(255, 255, 255, 0.25)',
+    color: 'white',
+  },
 };
 
 const Button = ({
@@ -60,8 +64,8 @@ Button.propTypes = {
   rightIcon: PropTypes.element,
   /** a value of `lg`, `md`, or `sm` */
   size: PropTypes.oneOf(['lg', 'md', 'sm']),
-  /** a value of `white` */
-  colorScheme: PropTypes.oneOf(Object.keys(colorSchemes)),
+  /** a value of `white` or `translucent` */
+  colorScheme: PropTypes.oneOf(['white', 'translucent']),
 };
 
 Button.defaultProps = {


### PR DESCRIPTION
This PR extends the `<Button />` component with a `translucent` color scheme.

```jsx
<Button colorScheme="translucent">...</Button>
```

<img width="300" alt="Screenshot 2022-01-20 at 8 40 48 PM" src="https://user-images.githubusercontent.com/464300/150411038-61182703-e441-47a1-aa19-b577091e8a6a.png">

