### PR TITLE
feat(Box): add bg gradient support

### DIFF
--- a/playground/stories/Box.stories.js
+++ b/playground/stories/Box.stories.js
@@ -1,8 +1,20 @@
 import React from 'react';
 import * as Cash from '@cash';
 
-export default () => (
-  <Cash.Box bg="black.10" p={3} _text={{ color: 'black.300' }} sx={{ bg: 'purple.100' }}>
-    Box
-  </Cash.Box>
-);
+export default () => {
+  const { gradients } = Cash.useTheme();
+
+  return (
+    <Cash.Stack direction="column" gap="20px">
+      <Cash.Box bg="black.10" p={3} _text={{ color: 'black.300' }} sx={{ bg: 'purple.100' }}>
+        Box
+      </Cash.Box>
+      <Cash.Box bgGradient={gradients.purple} p={3} _text={{ color: 'white' }}>
+        Box with bgGradient
+      </Cash.Box>
+      <Cash.Box bgGradient={gradients.pink} p={3} _text={{ color: 'white' }} borderRadius="md">
+        Box rounded with bgGradient
+      </Cash.Box>
+    </Cash.Stack>
+  );
+};

--- a/src/Box.js
+++ b/src/Box.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
+import LinearGradient from 'react-native-linear-gradient';
 import {
   space,
   color,
@@ -15,6 +16,9 @@ import Text from './Text';
 import sx from './sx';
 
 const StyledBox = styled.View(
+  {
+    overflow: 'hidden',
+  },
   space,
   color,
   typography,
@@ -26,9 +30,20 @@ const StyledBox = styled.View(
   sx
 );
 
-const Box = ({ children, _text, ...props }) => {
+const BgGradient = React.memo(
+  styled(LinearGradient)({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  })
+);
+
+const Box = ({ children, _text, bgGradient, ...props }) => {
   return (
     <StyledBox {...props}>
+      {bgGradient && <BgGradient {...bgGradient} />}
       {/** check for should render children as text */}
       {React.Children.map(children, child => {
         return typeof child === 'string' ||
@@ -47,6 +62,10 @@ const Box = ({ children, _text, ...props }) => {
 
 Box.propTypes = {
   _text: PropTypes.object,
+  bgGradient: PropTypes.shape({
+    colors: PropTypes.arrayOf(PropTypes.string),
+    locations: PropTypes.arrayOf(PropTypes.number),
+  }),
   sx: PropTypes.object,
 };
 


### PR DESCRIPTION
This PR adds background gradient support to the `<Box />` component e.g:

```jsx
<Box bgGradient={gradients.pink}>...</Box>
```

<img width="320" alt="Screenshot 2022-04-22 at 22 07 42" src="https://user-images.githubusercontent.com/464300/164786996-3bc15001-2f1e-4936-a745-22bab68c79c6.png">

