### PR TITLE
feat(Box): add iOS shadow support

### DIFF
--- a/playground/stories/Box.stories.js
+++ b/playground/stories/Box.stories.js
@@ -9,6 +9,15 @@ export default () => {
       <Cash.Box bg="black.10" p={3} _text={{ color: 'black.300' }} sx={{ bg: 'purple.100' }}>
         Box
       </Cash.Box>
+      <Cash.Box
+        shadow="md"
+        bg="white"
+        borderBottomLeftRadius="md"
+        borderBottomRightRadius="md"
+        p={3}
+      >
+        Box with shadow
+      </Cash.Box>
       <Cash.Box bgGradient={gradients.purple} p={3} _text={{ color: 'white' }}>
         Box with bgGradient
       </Cash.Box>

--- a/src/Box.js
+++ b/src/Box.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import LinearGradient from 'react-native-linear-gradient';
 import {
+  system,
   space,
   color,
   typography,
@@ -10,15 +11,19 @@ import {
   flexbox,
   background,
   border,
+  borderRadius,
   position,
 } from 'styled-system';
 import Text from './Text';
 import sx from './sx';
 
 const StyledBox = styled.View(
-  {
-    overflow: 'hidden',
-  },
+  system({
+    shadow: {
+      property: 'boxShadow',
+      scale: 'shadows',
+    },
+  }),
   space,
   color,
   typography,
@@ -31,19 +36,22 @@ const StyledBox = styled.View(
 );
 
 const BgGradient = React.memo(
-  styled(LinearGradient)({
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  })
+  styled(LinearGradient)(
+    {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    },
+    borderRadius
+  )
 );
 
 const Box = ({ children, _text, bgGradient, ...props }) => {
   return (
     <StyledBox {...props}>
-      {bgGradient && <BgGradient {...bgGradient} />}
+      {bgGradient && <BgGradient borderRadius={props.borderRadius} {...bgGradient} />}
       {/** check for should render children as text */}
       {React.Children.map(children, child => {
         return typeof child === 'string' ||
@@ -66,6 +74,8 @@ Box.propTypes = {
     colors: PropTypes.arrayOf(PropTypes.string),
     locations: PropTypes.arrayOf(PropTypes.number),
   }),
+  /** `shadows` from the theme */
+  shadow: PropTypes.string,
   sx: PropTypes.object,
 };
 

--- a/src/theme/shadows.js
+++ b/src/theme/shadows.js
@@ -1,6 +1,6 @@
 const shadows = {
   none: 'none',
-  // TODO: Box Shadows e.g. md: '0px 4px 4px 0px rgba(0, 0, 0, 0.12)',
+  md: '0px 4px 4px rgba(0, 0, 0, 0.12)',
 
   // Text Shadows
   text: {


### PR DESCRIPTION
This PR adds shadow support to the `<Box />` component e.g:

```jsx
<Box shadow="md">...</Box>
```

<img width="320" alt="Screenshot 2022-04-22 at 22 36 54" src="https://user-images.githubusercontent.com/464300/164790237-901245d9-44a5-45f9-88f5-682270dcb1b6.png">

